### PR TITLE
stats summary api indicates httproute and authorization policy are not valid to and from targets

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -133,6 +133,7 @@ var resourceNames = []resourceName{
 	{"srvauthz", "serverauthorization", "serverauthorizations"},
 	{"srv", "server", "servers"},
 	{"ap", "authorizationpolicy", "authorizationpolicies"},
+	{"httproute", "httproute", "httproutes"},
 	{"authzpolicy", "authorizationpolicy", "authorizationpolicies"},
 	{"sts", "statefulset", "statefulsets"},
 	{"ln", "link", "links"},

--- a/viz/metrics-api/stat_summary.go
+++ b/viz/metrics-api/stat_summary.go
@@ -77,8 +77,18 @@ func (s *grpcServer) StatSummary(ctx context.Context, req *pb.StatSummaryRequest
 	}
 
 	// err if --from is added with policy resources
-	if req.GetFromResource() != nil && isPolicyResource(req.GetSelector().GetResource()) {
-		return statSummaryError(req, "'from' queries are not supported with policy resources, as they have inbound metrics only"), nil
+	if req.GetFromResource() != nil {
+		if isPolicyResource(req.GetSelector().GetResource()) ||
+			isPolicyResource(req.GetFromResource()) {
+			return statSummaryError(req, "'from' queries are not supported with policy resources, as they have inbound metrics only"), nil
+		}
+	}
+
+	if req.GetToResource() != nil {
+		if isPolicyResource(req.GetSelector().GetResource()) ||
+			isPolicyResource(req.GetToResource()) {
+			return statSummaryError(req, "'to' queries are not supported with policy resources, as they have inbound metrics only"), nil
+		}
 	}
 
 	switch ob := req.Outbound.(type) {


### PR DESCRIPTION
stats summary api indicates httproute and authorization policy are not valid --from targets

signed-off-by : Pranoy Kumar Kundu <pranoy1998k@gmail.com>
![Screenshot from 2023-04-25 13-19-36](https://user-images.githubusercontent.com/34642702/234472431-9edaeaa5-fae5-4651-b1e2-bf9524841c2a.png)


